### PR TITLE
(fix) nullable parameter deprecation warnings - Version 1

### DIFF
--- a/src/Traits/NovaActivities.php
+++ b/src/Traits/NovaActivities.php
@@ -10,11 +10,11 @@ use Marshmallow\NovaActivity\Models\NovaActivity;
 trait NovaActivities
 {
     public function addActivity(
-        int $user_id = null,
-        int|string $type = null,
-        int|string|array $label = null,
-        string $comment = null,
-        Carbon $created_at = null,
+        ?int $user_id = null,
+        int|string|null $type = null,
+        int|string|array|null $label = null,
+        ?string $comment = null,
+        ?Carbon $created_at = null,
         array $quick_replies = [],
         array $mentions = [],
     ): NovaActivity {


### PR DESCRIPTION
## Summary
- Fixed 155 deprecation warnings caused by implicitly nullable parameters
- Explicitly marked parameters as nullable using `?` syntax instead of relying on default null values

## Changes
- Updated `addActivity` method parameters to use explicit nullable syntax:
  - `$user_id`: `int` → `?int`
  - `$type`: `int|string` → `int|string|null`
  - `$label`: `int|string|array` → `int|string|array|null`
  - `$comment`: `string` → `?string`
  - `$created_at`: `Carbon` → `?Carbon`

## Test plan
- [x] Verify no breaking changes to existing functionality
- [x] Confirm deprecation warnings are resolved

Resolves #15 (Version 1 - v-1-nova-4 branch)