### PR TITLE
Fix PHP 8.4 deprecation issues

### DIFF
--- a/src/Http/Controllers/CreateActivityController.php
+++ b/src/Http/Controllers/CreateActivityController.php
@@ -31,7 +31,7 @@ class CreateActivityController
                 }
             }
 
-            if ($comment_validation && !empty($comment_validation)) {
+            if ($comment_validation) {
                 $request->validate($comment_validation);
             }
 

--- a/src/Models/NovaActivity.php
+++ b/src/Models/NovaActivity.php
@@ -31,27 +31,28 @@ class NovaActivity extends Model
         $action = match ($action) {
             'pin' => function () {
                 $this->update(['is_pinned' => true]);
-                event(new ActivityPinned($this, auth()?->user()));
+                event(new ActivityPinned($this, auth()->user()));
             },
             'unpin' => function () {
                 $this->update(['is_pinned' => false]);
-                event(new ActivityUnpinned($this, auth()?->user()));
+                event(new ActivityUnpinned($this, auth()->user()));
             },
             'hide' => function () {
                 $this->update(['is_hidden' => true]);
-                event(new ActivityCommentHidden($this, auth()?->user()));
+                event(new ActivityCommentHidden($this, auth()->user()));
             },
             'show' => function () {
                 $this->update(['is_hidden' => false]);
-                event(new ActivityCommentShow($this, auth()?->user()));
+                event(new ActivityCommentShow($this, auth()->user()));
             },
             'delete' => function () {
                 $this->delete();
-                event(new ActivityDeleted($this, auth()?->user()));
+                event(new ActivityDeleted($this, auth()->user()));
             },
+            default => throw new \InvalidArgumentException("Unknown action: {$action}"),
         };
 
-        return $action();
+        $action();
     }
 
     public function getOtherQuickReplies()

--- a/src/Resources/NovaActivityResource.php
+++ b/src/Resources/NovaActivityResource.php
@@ -19,8 +19,8 @@ class NovaActivityResource extends JsonResource
         return [
             'id' => $this->id,
             'user' => [
-                'id' => $this->user?->id ?? null,
-                'name' => $this->user?->name ?? __('System'),
+                'id' => $this->user->id ?? null,
+                'name' => $this->user->name ?? __('System'),
                 'avatar' => Activity::getUserAvatar($this->user),
                 'icon' => $this->user ? null : 'desktop-computer',
             ],


### PR DESCRIPTION
## Summary
This PR resolves PHP 8.4 deprecation warnings identified in issue #19:

- Fixed redundant empty() check in CreateActivityController that was always truthy
- Added default case to match expression in NovaActivity model to handle unexpected string values  
- Removed unnecessary nullsafe operators on auth() calls (auth() returns non-nullable AuthManager)
- Fixed closure return usage in runAction method (void closures shouldn't return values)
- Removed redundant nullsafe operators in NovaActivityResource when using null coalescing

## Changes Made
- `src/Http/Controllers/CreateActivityController.php`: Simplified validation condition
- `src/Models/NovaActivity.php`: Added default case to match, removed nullsafe operators, fixed void return
- `src/Resources/NovaActivityResource.php`: Removed unnecessary nullsafe operators

## Test Plan
- All existing functionality should continue to work as expected
- PHP 8.4 deprecation warnings should be resolved
- Error handling improved with explicit exception for unknown actions

Fixes #19