### PR TITLE
fix: translations publish tag typo (nova-activiy → nova-activity)

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ php artisan vendor:publish --tag="nova-activity-migrations"
 ```
 
 ```bash
-php artisan vendor:publish --tag="nova-activiy-translations"
+php artisan vendor:publish --tag="nova-activity-translations"
 ```
 
 ```php

--- a/src/FieldServiceProvider.php
+++ b/src/FieldServiceProvider.php
@@ -40,7 +40,7 @@ class FieldServiceProvider extends ServiceProvider
 
         $this->publishes([
             __DIR__ . '/../resources/lang' => $this->app->langPath('vendor/nova-activity'),
-        ], 'nova-activiy-translations');
+        ], 'nova-activity-translations');
     }
 
     /**


### PR DESCRIPTION
The translations publish tag was misspelled `nova-activiy-translations`. Corrected to `nova-activity-translations` in the service provider and README.

**Minor behavioral change:** this renames the published `vendor:publish` tag. Anyone scripting the old (misspelled) `nova-activiy-translations` tag must update to `nova-activity-translations`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)